### PR TITLE
Adding a Paginator to fix Kaminari & WillPaginate conflicts.

### DIFF
--- a/app/controllers/upmin/models_controller.rb
+++ b/app/controllers/upmin/models_controller.rb
@@ -45,7 +45,7 @@ module Upmin
 
     def search
       @q = @klass.ransack(params[:q])
-      @results = @q.result(distinct: true).page(@page).per(30)
+      @results = Upmin::Paginator.paginate(@q.result(distinct: true), @page, 30)
     end
 
     def action
@@ -80,7 +80,7 @@ module Upmin
       end
 
       def set_page
-        @page = params[:page] || 0
+        @page = params[:page] || 1
       end
 
       # TODO(jon): Figure out a better way to do transforms that is easy to extend.

--- a/app/views/upmin/models/search.html.haml
+++ b/app/views/upmin/models/search.html.haml
@@ -4,7 +4,7 @@
       -# TODO(jon): Add pagination w/ search results
       = up_search_results(@q, @results)
       %br
-      = paginate @results
+      = up_paginate @results
       %br
       %br
     .col-md-4

--- a/lib/upmin/admin.rb
+++ b/lib/upmin/admin.rb
@@ -4,8 +4,11 @@ require "upmin/engine"
 require "upmin/klass"
 require "upmin/model"
 
+require "upmin/paginator"
+
 # Monkey patch code into rails
 require "upmin/railties/active_record"
+require "upmin/railties/paginator"
 require "upmin/railties/render"
 require "upmin/railties/render_helpers"
 require "upmin/railtie"
@@ -15,7 +18,9 @@ require "jquery-rails"
 require "ransack"
 require "haml"
 require "sass-rails"
-require "kaminari"
+
+# If WillPaginate is present we just use it, but by default upmin-admin uses Kaminari
+require "kaminari" unless defined?(WillPaginate)
 
 module Upmin
   module Admin

--- a/lib/upmin/paginator.rb
+++ b/lib/upmin/paginator.rb
@@ -1,0 +1,14 @@
+module Upmin
+  module Paginator
+
+    def Paginator.paginate(chain, page = 1, per_page = 30)
+      if defined?(WillPaginate)
+        # Ignore per page for now - just use the will_paginate default
+        return chain.page(page.to_i)
+      else # Use Kaminari
+        return chain.page(page).per(per_page)
+      end
+    end
+
+  end
+end

--- a/lib/upmin/railtie.rb
+++ b/lib/upmin/railtie.rb
@@ -9,10 +9,12 @@ module Upmin
 
       ActiveSupport.on_load(:action_controller) do
         ::ActionController::Base.send(:include, Upmin::Railties::Render)
+        ::ActionController::Base.send(:include, Upmin::Railties::Paginator)
       end
 
       ActiveSupport.on_load(:action_view) do
         ::ActionView::Base.send(:include, Upmin::Railties::Render)
+        ::ActionView::Base.send(:include, Upmin::Railties::Paginator)
       end
     end
   end

--- a/lib/upmin/railties/paginator.rb
+++ b/lib/upmin/railties/paginator.rb
@@ -1,0 +1,14 @@
+
+module Upmin::Railties
+  module Paginator
+
+    def up_paginate(scope, options = {}, &block)
+      if defined?(WillPaginate)
+        return will_paginate(scope, options)
+      else # Use Kaminari
+        return paginate(scope, options, &block)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Alternatively we could use the solution active_admin uses (make the user define a new per_page_method for Kaminari) but that either puts more work on the user's end, or has the potential side effect of breaking other gems. This way isn't perfect (our page select html in views are rendered differently for will_paginate and kaminari) but it seems like a solid start that prevents any extra work for users of upmin-admin.
