### PR TITLE
Support for custom model names

### DIFF
--- a/app/controllers/upmin/models_controller.rb
+++ b/app/controllers/upmin/models_controller.rb
@@ -27,7 +27,7 @@ module Upmin
       @model = @klass.new
       instance = @model.instance
 
-      args = params[@klass.name.underscore]
+      args = params[@klass.model.name.underscore]
       transforms = args.delete(:transforms) || {}
 
       args.each do |key, value|
@@ -63,7 +63,7 @@ module Upmin
     # PUT /:model_name/:id
     def update
       instance = @model.instance
-      updates = params[@klass.name.underscore]
+      updates = params[@klass.model.name.underscore]
       transforms = updates.delete(:transforms) || {}
 
       updates.each do |key, value|

--- a/lib/upmin/klass.rb
+++ b/lib/upmin/klass.rb
@@ -101,7 +101,7 @@ module Upmin
     # Returns the class name, split at camelCase,
     # with the last word pluralized if it is plural.
     def humanized_name(type = :plural)
-      names = model.name.split(/(?=[A-Z])/)
+      names = name.split(/(?=[A-Z])/).map(&:strip)
       if type == :plural
         names[names.length-1] = names.last.pluralize
       end
@@ -110,7 +110,13 @@ module Upmin
 
     # Returns the class name, capitalized as it would be with User.name or OrderShipment.name - "User", or "OrderShipment"
     def name
-      return model.name
+      if Upmin::Model.model_names.has_key?(model)
+        Upmin::Model.model_names[model]
+      elsif model.respond_to?(:upmin_name)
+        model.upmin_name
+      else
+        model.name
+      end
     end
 
     def path_hash
@@ -126,7 +132,7 @@ module Upmin
     # Takes a Rails ActiveRecord or the name of one and returns an
     # Upmin::Klass instance of the model.
     def Klass.find(model)
-      return all.select{|k| k.name == model.to_s}.first
+      return all.detect{|k| k.model.name == model.to_s || k.name == model.to_s}
     end
 
     # Returns an array of all Klass instances

--- a/lib/upmin/model.rb
+++ b/lib/upmin/model.rb
@@ -1,6 +1,16 @@
 module Upmin
   class Model
 
+    class << self
+
+      attr_writer :model_names
+
+      def model_names
+        @model_names ||= {}
+      end
+
+    end
+
     attr_accessor :instance
     attr_accessor :klass
 


### PR DESCRIPTION
I think that custom model names (what is displayed in menu and in controls) would be very useful.

This implementation is just a prototype, I am curions what you think about this feature.

I think it could be easily integrated with "configuration" feature implemented in #36 later.

This implementation allows setting of custom names via 2 ways.

``` ruby
# user_persistance.rb
class UserPersistance
  def self.upmin_name
    'User'
  end
end
```

or

``` ruby
# initializers/upmin.rb
Upmin::Model.model_names = {
  UserPersistance => 'User',
}
```
