### PR TITLE
Remove Rails 4.2 specific requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Upmin Admin
 
-Upmin Admin is a framework for creating powerful admin backends with minimal effort.
 [![Gem Version](https://badge.fury.io/rb/upmin-admin.svg)](http://badge.fury.io/rb/upmin-admin)
+
+Upmin Admin is a framework for creating powerful Ruby on Rails admin backends with minimal effort.
+
+Upmin Admin currently supports Rails 3.2, 4.0, 4.1 & 4.2.
 
 
 ## Demo Videos


### PR DESCRIPTION
ransack rails-4.2 branch has been merged into master and is no longer actively maintained.

Edit: Add list of Rails version supported based on test_apps.
