### PR TITLE
Option to set items per page, globally. 

### DIFF
--- a/app/controllers/upmin/models_controller.rb
+++ b/app/controllers/upmin/models_controller.rb
@@ -117,7 +117,7 @@ module Upmin
       end
 
       def set_query
-        @query = Upmin::Query.new(@klass, params[:q], page: @page, per_page: 30)
+        @query = Upmin::Query.new(@klass, params[:q], page: @page, per_page: Model.items_per_page)
       end
 
       def set_model

--- a/lib/upmin/configuration.rb
+++ b/lib/upmin/configuration.rb
@@ -45,6 +45,19 @@ module Upmin
       end
     end
 
+    def items_per_page=(items)
+      @custom_items_per_page = true
+      @items_per_page = items
+    end
+
+    def items_per_page
+      if defined?(@custom_items_per_page)
+        return @items_per_page
+      else
+        return 30
+      end
+    end
+
     private
 
       def default_models

--- a/lib/upmin/model.rb
+++ b/lib/upmin/model.rb
@@ -219,6 +219,9 @@ module Upmin
       end
     end
 
+    def Model.items_per_page
+      return Upmin.configuration.items_per_page
+    end
 
 
     ###########################################################

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -57,4 +57,17 @@ describe Upmin::Configuration do
 
   end
 
+  describe "#items_per_page" do
+
+    context "default items_per_page" do
+      it { expect(@config.items_per_page).to(eq(30)) }
+    end
+
+    context "custom items_per_page" do
+      before(:each) { @config.items_per_page = 10 }
+      it { expect(@config.items_per_page).to(eq(10)) }
+    end
+
+  end
+
 end


### PR DESCRIPTION
Partially resolves #67 - Allows a user to override the default of 30 items per page with a global config option.

For example in config/initializers/upmin_admin.rb add:

Upmin.configure do |config|
  config.items_per_page = 10
end

Per-model configuration to follow in a later PR.
