### PR TITLE
Allow deep inheritance of ActiveRecord::Base.

### DIFF
--- a/lib/upmin/model.rb
+++ b/lib/upmin/model.rb
@@ -201,7 +201,7 @@ module Upmin
 
     def Model.active_record?
       if defined?(ActiveRecord)
-        return model_class.superclass == ::ActiveRecord::Base
+        return (model_class < ::ActiveRecord::Base) == true
       else
         return false
       end


### PR DESCRIPTION
We have a model that inheritance from another model, the active_record? check doesn't work correctly.

Class A < ActiveRecord::Base
end

Class B < A
end
