### PR TITLE
change dependency of bundler/gem_tasks in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,7 @@
 #!/usr/bin/env rake
 # encoding: utf-8
 
-require 'bundler'
-Bundler::GemHelper.install_tasks
+require 'bundler/gem_tasks'
 
 require 'rspec/core'
 require 'rspec/core/rake_task'


### PR DESCRIPTION
Require the whole bundle is not needed since may 2011
[Changelog](https://github.com/bundler/bundler/blob/master/CHANGELOG.md#1014-may-27-2011)
[Commit, changing dependency](https://github.com/bundler/bundler/commit/3903dfd5038aefd078bca0cba3533b155b615591)
