### PR TITLE
Database column with name "title" returns wrong data

### DIFF
--- a/lib/upmin/attribute.rb
+++ b/lib/upmin/attribute.rb
@@ -10,7 +10,7 @@ module Upmin
 
     def value
       # TODO(jon): Add some way to handle exceptions.
-      return model.send(name)
+      return model.model.send(name)
     end
 
     def type


### PR DESCRIPTION
https://github.com/upmin/upmin-admin-ruby/issues/107

Upmin::Attribute#value needs to refer to the ActiveModel instance, not Upmin::Model instance.
