### PR TITLE
Use .to_s instead of .to_sym to compare action.name

### DIFF
--- a/app/controllers/upmin/models_controller.rb
+++ b/app/controllers/upmin/models_controller.rb
@@ -129,8 +129,8 @@ module Upmin
       end
 
       def set_action
-        action_name = params[:method].to_sym
-        @action = @model.actions.select{ |action| action.name == action_name }.first
+        action_name = params[:method]
+        @action = @model.actions.select{ |action| action.name.to_s == action_name }.first
 
         raise Upmin::InvalidAction.new(params[:method]) unless @action
       end


### PR DESCRIPTION
to avoid DoS through params[].to_sym memory leak

http://brakemanscanner.org/docs/warning_types/denial_of_service/

https://github.com/upmin/upmin-admin-ruby/issues/110
