### PR TITLE
attribute.name and association.name partial paths  

### DIFF
--- a/lib/upmin/railties/render_helpers.rb
+++ b/lib/upmin/railties/render_helpers.rb
@@ -75,6 +75,7 @@ module Upmin::Railties
       partials << build_association_path(options[:as]) if options[:as]
       partials << build_association_path("#{model_name}_#{association.name}")
       partials << build_association_path("#{model_name}_#{assoc_type}")
+      partials << build_association_path(association.name)
       partials << build_association_path(assoc_type)
       partials << build_association_path(:associations)
       return partials


### PR DESCRIPTION
This allows you to specify partial overrides based on attribute or association name for the whole system and not only on specific models.

I needed to customize an attribute's partial with a file_field input on more than one model. E.g.,

```
class Product < ActiveRecord::Base
  mount_uploader :image, ImageUploader
end

class Post < ActiveRecord::Base
  mount_uploader :image, ImageUploader
end
```

I can now add a partial to `app/views/upmin/partials/attributes/_image.html.haml` to override the attribute's partial for both models in Upmin.
