### PR TITLE
Allow searching on date fields

### DIFF
--- a/app/views/upmin/partials/search_boxes/_ransack_search_box.html.haml
+++ b/app/views/upmin/partials/search_boxes/_ransack_search_box.html.haml
@@ -22,7 +22,7 @@
           .input-group-addon to
           = number_field(:q, "#{attr_name}_lteq", class: "form-control")
 
-    - if type == :datetime && Rails::VERSION::MAJOR == 4
+    - if [:datetime, :date].include?(type) && Rails::VERSION::MAJOR == 4
       -# TODO(jon): Add date fields to search boxes for Rails 3
       .form-group
         = label(:q, "#{attr_name}_cont", attr_name.to_s.capitalize.gsub("_", " "))


### PR DESCRIPTION
The date search fields would appear for DateTime fields but not Date fields. This pull request allows Date fields to be searchable too.

There are no tests around this... I couldn't get them to work with the 32 test app. I guess you had a similar problem because there were no tests around the current date search control. :grin: 