### PR TITLE
Exclude HABTM from Upmin::Configuration.models to address #123

### DIFF
--- a/lib/upmin/configuration.rb
+++ b/lib/upmin/configuration.rb
@@ -76,6 +76,7 @@ module Upmin
           def_models += ::ActiveRecord::Base.descendants
             .map(&:to_s)
             .select{ |m| m != "ActiveRecord::SchemaMigration" }
+            .select{ |m| m.exclude? "HABTM" }
             .sort
             .map(&:underscore)
             .map(&:to_sym)


### PR DESCRIPTION
Doesn't include tests, as HABTM associations are declared differently in Rails 3 & 4, but the model definitions are shared between tests in the current test suite.