### PR TITLE
Support for customized model name, addressing #65

### DIFF
--- a/lib/upmin/model.rb
+++ b/lib/upmin/model.rb
@@ -170,10 +170,12 @@ module Upmin
     end
 
     def Model.humanized_name(type = :plural)
-      names = model_class_name.split(/(?=[A-Z])/).map{|n| n.gsub(":", "")}
+      names = @display_name ? [@display_name] : model_class_name.split(/(?=[A-Z])/).map{|n| n.gsub(":", "")}
+
       if type == :plural
         names[names.length-1] = names.last.pluralize
       end
+
       return names.join(" ")
     end
 
@@ -284,6 +286,10 @@ module Upmin
 
     def Model.items_per_page(items = Upmin.configuration.items_per_page)
       return @items_per_page ||= items
+    end
+
+    def Model.display_name (name)
+      return @display_name ||= name
     end
 
 

--- a/spec/features/edit_model_spec.rb
+++ b/spec/features/edit_model_spec.rb
@@ -41,7 +41,7 @@ feature("Update an existing model") do
     click_button("Save")
 
     within(".alert.alert-danger") do
-      expect(page).to(have_content("User was NOT updated."))
+      expect(page).to(have_content("Customer was NOT updated."))
       expect(page).to(have_selector("li", text: /email/i))
     end
 

--- a/spec/features/navbar_spec.rb
+++ b/spec/features/navbar_spec.rb
@@ -10,13 +10,13 @@ feature("Navbar") do
     visit ("/upmin")
 
     within(".navbar ul.nav") do
-      expect(page).to(have_selector("li", text: "Users"))
+      expect(page).to(have_selector("li", text: "Customers"))
       expect(page).to(have_selector("li", text: "Products"))
       expect(page).to(have_selector("li", text: "Orders"))
       expect(page).to(have_selector("li", text: "Product Orders"))
       expect(page).to(have_selector("li", text: "Shipments"))
 
-      click_link("Users")
+      click_link("Customers")
     end
 
     expect(page).to(have_selector(".upmin-model", minimum: 10))
@@ -30,13 +30,13 @@ feature("Navbar") do
     visit ("/upmin")
 
     within(".navbar ul.nav") do
-      expect(page).to(have_selector("li", text: "Users"))
+      expect(page).to(have_selector("li", text: "Customers"))
       expect(page).to(have_selector("li", text: "Products"))
       expect(page).not_to(have_selector("li", text: "Orders"))
       expect(page).not_to(have_selector("li", text: "Product Orders"))
       expect(page).not_to(have_selector("li", text: "Shipments"))
 
-      click_link("Users")
+      click_link("Customers")
     end
 
     expect(page).to(have_selector(".upmin-model", minimum: 10))

--- a/spec/features/new_model_spec.rb
+++ b/spec/features/new_model_spec.rb
@@ -34,7 +34,7 @@ feature("Create a new model") do
     expect { click_button("Create") }.not_to(change(User, :count))
 
     within(".alert.alert-danger") do
-      expect(page).to(have_content("User was NOT created."))
+      expect(page).to(have_content("Customer was NOT created."))
     end
 
     within(".field_with_errors") do

--- a/test_app_upmin/models/admin_user.rb
+++ b/test_app_upmin/models/admin_user.rb
@@ -1,5 +1,7 @@
 class AdminUser < Upmin::Model
 
+  display_name "Customer"
+
   action :issue_coupon
 
 end


### PR DESCRIPTION
Enables `display_name "Name"` in an AdminModel, following the pattern shown in #46.

