### PR TITLE
Option to set per-model sort column and order, addressing #48.

### DIFF
--- a/lib/upmin/active_record/query.rb
+++ b/lib/upmin/active_record/query.rb
@@ -2,11 +2,10 @@ module Upmin::ActiveRecord
   module Query
 
     def results
-      return klass.model_class.ransack(search_options).result(distinct: true)
+      return klass.model_class.ransack(search_options).result(distinct: true).order(klass.sort_order)
     end
 
     private
-
 
   end
 end

--- a/lib/upmin/data_mapper/query.rb
+++ b/lib/upmin/data_mapper/query.rb
@@ -21,6 +21,7 @@ module Upmin::DataMapper
             end
           end
         end
+        @prepared_search[:order] = [ klass.sort_order ]
         return @prepared_search
       end
 

--- a/lib/upmin/model.rb
+++ b/lib/upmin/model.rb
@@ -282,10 +282,28 @@ module Upmin
       return @actions
     end
 
+    # Set the number of items per page to display in search results.
     def Model.items_per_page(items = Upmin.configuration.items_per_page)
       return @items_per_page ||= items
     end
 
+    # Set the default sort column & order for search results.
+    def Model.sort_order(order = orm_default_order)
+      return @sort_order ||= order
+    end
+
+    # Returns a default sort order for the Model ORM (primary-key column, ascending)
+    def Model.orm_default_order
+      if active_record?
+        return model_class.primary_key
+      elsif data_mapper?
+        # DataMapper has `Model.key`, => [#<DataMapper::Property::Serial @model=ModelName @name=:id>]
+        # I'm assuming @name to be the primary key...
+        return model_class.key.first.name.asc
+      else # Unknown ORM
+        return
+      end
+    end
 
     ###########################################################
     ### Methods that need to be to be overridden. If the

--- a/lib/upmin/query.rb
+++ b/lib/upmin/query.rb
@@ -44,7 +44,6 @@ module Upmin
       return @upmin_results
     end
 
-
     private
 
   end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -101,4 +101,13 @@ feature("Search Views") do
     Upmin.configuration = Upmin::Configuration.new
   end
 
+  scenario("Shipments with `sort_order 'id desc'` ") do
+    expected_shipment = Shipment.last
+
+    visit("/upmin/m/Shipment")
+    within(".search-result-link:first-of-type") do
+      expect(page).to(have_content("Id #{expected_shipment.id}"))
+    end
+  end
+
 end

--- a/test_app_upmin/models/admin_shipment.rb
+++ b/test_app_upmin/models/admin_shipment.rb
@@ -6,7 +6,14 @@ class AdminShipment < Upmin::Model
   action :update_shipment
   action :pretend_to_work
 
+  # Configuration
   items_per_page 20
+  if defined?(DataMapper)
+    sort_order :id.desc
+  else
+    sort_order 'id DESC'
+  end
+
 
   def status
     return "TestStatus"


### PR DESCRIPTION
Allows the addition of `sort_order <options>` to an AdminModel to change the sort column & order for that model. Accepts whatever options the ORM does for its sort method, including multi-column sort.

Addresses (at least in part) #48.