### PR TITLE
namespaced_model needs an ActsAsTaggableOn::Tag to pass the test

### DIFF
--- a/spec_namespaced_model/taggable_spec.rb
+++ b/spec_namespaced_model/taggable_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 
 feature("Taggable Search Views") do
   background do
-    # Setup BG Stuff
+    ActsAsTaggableOn::Tag.create(name: 'test')
   end
 
   scenario("Acts As Taggable On Tags") do


### PR DESCRIPTION
Tests were broken

```
Failures:

  1) Taggable Search Views Acts As Taggable On Tags
     Failure/Error: expect(page).to(have_selector("a.search-result-link", count: 1))
       expected to find css "a.search-result-link" 1 time but there were no matches
     # ./spec/namespaced_model/taggable_spec.rb:13:in `block (2 levels) in <top (required)>'

Finished in 5.86 seconds (files took 1.44 seconds to load)
41 examples, 1 failure

Failed examples:

rspec ./spec/namespaced_model/taggable_spec.rb:9 # Taggable Search Views Acts As Taggable On Tags

Randomized with seed 7310
```
