### PR TITLE
Better boolean/enum state display

### DIFF
--- a/app/views/upmin/partials/attributes/_boolean.html.haml
+++ b/app/views/upmin/partials/attributes/_boolean.html.haml
@@ -2,9 +2,4 @@
   %label{for: attribute.form_id}
     = attribute.label_name
 
-  - if attribute.editable? && f = form_builder
-    = f.check_box(attribute.name, value: boolean, class: "boolean")
-
-  - else
-    %p.well
-      = attribute.value
+  = form_builder.check_box(attribute.name, value: boolean, class: "boolean", disabled: !attribute.editable?)

--- a/app/views/upmin/partials/attributes/_enum.html.haml
+++ b/app/views/upmin/partials/attributes/_enum.html.haml
@@ -2,13 +2,8 @@
   %label{for: attribute.form_id}
     = attribute.label_name
 
-  - if attribute.editable? && f = form_builder
-    .enum
-      - attribute.enum_options.each do |option|
-        %label.radio-inline
-          = f.radio_button attribute.name, option
-          = option.humanize
-
-  - else
-    %p.well
-      = attribute.value
+  .enum
+    - attribute.enum_options.each do |option|
+      %label.radio-inline
+        = form_builder.radio_button attribute.name, option, disabled: !attribute.editable?
+        = option.humanize


### PR DESCRIPTION
I think it makes sense to use the original form controls for uneditable fields, just using their disabled state. I'm guessing you guys didn't have a need for this since the only uneditable fields previously were ints/strings?