### PR TITLE
[WIP] Allow restricting CRUD actions

### DIFF
--- a/app/views/upmin/models/search.html.haml
+++ b/app/views/upmin/models/search.html.haml
@@ -28,8 +28,9 @@
     .col-md-4
       -# TODO(jon): Implement up_search_box
       = up_render(@klass)
-      .new-button-wrapper
-        %a.btn.btn-block.btn-success{href: upmin_new_model_path(klass: @klass.model_class_name)}
-          Create a new
-          = @klass.humanized_name(:singular)
-        %br
+      - if @klass.crud_actions.include? :new
+        .new-button-wrapper
+          %a.btn.btn-block.btn-success{href: upmin_new_model_path(klass: @klass.model_class_name)}
+            Create a new
+            = @klass.humanized_name(:singular)
+          %br

--- a/app/views/upmin/partials/models/_model.html.haml
+++ b/app/views/upmin/partials/models/_model.html.haml
@@ -2,8 +2,9 @@
   %h3
     = model.title
 
-    = link_to(model.path, method: :delete, class: "btn btn-sm btn-danger delete pull-right", title: "Delete #{model.title}.", data: {confirm: "Are you sure?"}) do
-      %span.glyphicon.glyphicon-trash.white
+    - if model.crud_actions.include? :destroy
+      = link_to(model.path, method: :delete, class: "btn btn-sm btn-danger delete pull-right", title: "Delete #{model.title}.", data: {confirm: "Are you sure?"}) do
+        %span.glyphicon.glyphicon-trash.white
 
   %br
   %h3{style: "color: #333;"}
@@ -18,7 +19,8 @@
       - model.attributes.each do |attribute|
         = up_render(attribute, locals: { form_builder: f })
 
-      = f.submit("Save", class: "btn btn-primary")
+      - if model.crud_actions.include? :create
+        = f.submit("Save", class: "btn btn-primary")
 
   - if model.associations.any?
     %br

--- a/lib/upmin/active_record/model.rb
+++ b/lib/upmin/active_record/model.rb
@@ -25,6 +25,10 @@ module Upmin::ActiveRecord
         return model_class.attribute_names.map(&:to_sym)
       end
 
+      def default_crud_actions
+        return [:index, :create, :new, :edit, :show, :update, :destroy]
+      end
+
       def attribute_type(attribute)
         adapter = model_class.columns_hash[attribute.to_s]
         if adapter

--- a/lib/upmin/model.rb
+++ b/lib/upmin/model.rb
@@ -50,6 +50,12 @@ module Upmin
       return @attributes
     end
 
+    def crud_actions
+      return @crud_actions if defined?(@crud_actions)
+      @crud_actions = self.class.crud_actions
+      return @crud_actions
+    end
+
     def associations
       return @associations if defined?(@associations)
       @associations = []
@@ -258,6 +264,18 @@ module Upmin
       return (@attributes + @extra_attrs).uniq
     end
 
+    # Sets the CRUD actions to the provided attributes if any are provided.
+    # If no actions are provided then the actions are set to the default
+    # actions of the model class.
+    def Model.crud_actions(*crud_actions)
+      if crud_actions.any?
+        @crud_actions = crud_actions.map{|a| a.to_sym}
+      end
+      @crud_actions ||= default_crud_actions
+
+      return @crud_actions
+    end
+
     # Add a single action to upmin actions. If this is called
     # before upmin_actions the actions will not include any defaults
     # actions.
@@ -302,6 +320,11 @@ module Upmin
     def Model.default_attributes
       new
       return default_attributes
+    end
+
+    def Model.default_crud_actions
+      new
+      return default_crud_actions
     end
 
     def Model.attribute_type(attribute)


### PR DESCRIPTION
Allow specifying which of the default CRUD actions are available in Upmin::Models. These actions need to also be:

1. restricted in `ModelController`
2. excluded from views so as to not show buttons for actions that are
unavailable

for this to do any good. I haven't done anything with `ModelController` but I have done some view customization, hence the [WIP] tag.