### PR TITLE
Customizable model associations

### DIFF
--- a/lib/upmin/active_record/model.rb
+++ b/lib/upmin/active_record/model.rb
@@ -45,8 +45,8 @@ module Upmin::ActiveRecord
         end
       end
 
-      def associations
-        return @associations if defined?(@associations)
+      def default_associations
+        return @default_associations if defined?(@default_associations)
 
         all = []
         ignored = []
@@ -59,7 +59,7 @@ module Upmin::ActiveRecord
           end
         end
 
-        return @associations = (all - ignored).uniq
+        return @default_associations = (all - ignored).uniq
       end
 
     end

--- a/lib/upmin/model.rb
+++ b/lib/upmin/model.rb
@@ -286,6 +286,18 @@ module Upmin
       return @items_per_page ||= items
     end
 
+    # Sets the associations to the provided associations if any are any
+    # provided. If no associations are provided then the associations are set to
+    # the default associations of the model class.
+    def Model.associations(*associations)
+      if associations.any?
+        @associations = associations.map{|a| a.to_sym}
+      end
+      @associations ||= default_associations
+
+      return @associations
+    end
+
 
     ###########################################################
     ### Methods that need to be to be overridden. If the
@@ -302,6 +314,11 @@ module Upmin
     def Model.default_attributes
       new
       return default_attributes
+    end
+
+    def Model.default_associations
+      new
+      return default_associations
     end
 
     def Model.attribute_type(attribute)


### PR DESCRIPTION
Provide a way to customize which associations are displayed when showing a model.

I have just realized that I've been completely ignoring the DataMapper adapter and only modifying the ActiveRecord class. :-/