### PR TITLE
Add a "money in cents" attribute partial

### DIFF
--- a/app/views/upmin/partials/attributes/_money_cents.html.haml
+++ b/app/views/upmin/partials/attributes/_money_cents.html.haml
@@ -1,0 +1,10 @@
+-# based on "unknown" attribute type partial; does not allow editing (would
+-# have to parse the string back into cents, which is fraught with danger)
+.form-group{class: attribute.errors? ? "has-error" : ""}
+  %label{for: attribute.form_id}
+    = attribute.label_name.gsub('cents', '')
+  %p.well
+    - if attribute.value.respond_to?(:/)
+      = number_to_currency(attribute.value / 100.to_f)
+    - else
+      = attribute.value


### PR DESCRIPTION
Add an attribute partial for showing attributes that are an amount of money in
units of cents, or more specifically:

1. Strips "cents" from the label
2. Divides the amount by 100 to get whole dollars
3. Shows the currency symbol

Note that this (similar to the progress bar partial) does not allow editing of the amount. It would be possible to implement this, but it you'd have to parse the user input back into cents, which seems like it could go wrong in more ways than I want to deal with right now.

(Partially) fixes #155.