### PR TITLE
Customizable attribute value display

### DIFF
--- a/app/views/upmin/partials/attribute_values/_boolean.html.haml
+++ b/app/views/upmin/partials/attribute_values/_boolean.html.haml
@@ -1,0 +1,1 @@
+%span.badge= attribute.value ? 'Yes' : 'No'

--- a/app/views/upmin/partials/attribute_values/_enum.html.haml
+++ b/app/views/upmin/partials/attribute_values/_enum.html.haml
@@ -1,0 +1,1 @@
+%span.badge= attribute.value

--- a/app/views/upmin/partials/attribute_values/_unknown.html.haml
+++ b/app/views/upmin/partials/attribute_values/_unknown.html.haml
@@ -1,0 +1,1 @@
+= attribute.value

--- a/app/views/upmin/partials/attributes/_datetime.html.haml
+++ b/app/views/upmin/partials/attributes/_datetime.html.haml
@@ -35,4 +35,4 @@
   - else
     %p.well
       -# TODO(jon): Make this show an uneditable date and time field.
-      = iso8601
+      = up_render(attribute.display_value)

--- a/app/views/upmin/partials/search_results/_results.html.haml
+++ b/app/views/upmin/partials/search_results/_results.html.haml
@@ -6,4 +6,4 @@
           %dt
             = attribute.label_name
           %dd
-            = attribute.value
+            = up_render(attribute.display_value)

--- a/lib/upmin/admin.rb
+++ b/lib/upmin/admin.rb
@@ -8,6 +8,7 @@ require "upmin/paginator"
 
 require "upmin/model"
 require "upmin/attribute"
+require "upmin/attribute_value"
 require "upmin/association"
 require "upmin/action"
 require "upmin/parameter"

--- a/lib/upmin/attribute.rb
+++ b/lib/upmin/attribute.rb
@@ -13,6 +13,12 @@ module Upmin
       return model.model.send(name)
     end
 
+    def display_value
+      return @display_value if defined?(@display_value)
+      @display_value = Upmin::AttributeValue.new(self)
+      return @display_value
+    end
+
     def type
       # TODO(jon): Add a way to override with widgets?
       return @type if defined?(@type)

--- a/lib/upmin/attribute_value.rb
+++ b/lib/upmin/attribute_value.rb
@@ -1,0 +1,10 @@
+module Upmin
+  class AttributeValue
+    attr_reader :attribute
+    
+    def initialize(attribute, options = {})
+      @attribute = attribute
+    end
+
+  end
+end

--- a/lib/upmin/railties/render.rb
+++ b/lib/upmin/railties/render.rb
@@ -12,6 +12,10 @@ module Upmin::Railties
         options = RenderHelpers.attribute_options(data, options)
         partials = RenderHelpers.attribute_partials(data, options)
 
+      elsif data.is_a?(Upmin::AttributeValue)
+        options = RenderHelpers.attribute_value_options(data, options)
+        partials = RenderHelpers.attribute_value_partials(data, options)
+
       elsif data.is_a?(Upmin::Association)
         options = RenderHelpers.association_options(data, options)
         partials = RenderHelpers.association_partials(data, options)

--- a/lib/upmin/railties/render_helpers.rb
+++ b/lib/upmin/railties/render_helpers.rb
@@ -61,6 +61,41 @@ module Upmin::Railties
 
 
 
+    def RenderHelpers.attribute_value_partials(attribute_value, options = {})
+      attribute = attribute_value.attribute
+      partials = []
+      # <options[:as]>
+      # <model_name>_<attr_name>, eg: user_name
+      # <model_name>_<attr_type>, eg: user_string
+      # <attr_type>, eg: string
+      # unknown
+
+      model_name = attribute.model.underscore_name
+      attr_type = attribute.type
+
+      partials << build_attribute_value_path(options[:as]) if options[:as]
+      partials << build_attribute_value_path("#{model_name}_#{attribute.name}")
+      partials << build_attribute_value_path("#{model_name}_#{attr_type}")
+      partials << build_attribute_value_path(attribute.name)
+      partials << build_attribute_value_path(attr_type)
+      partials << build_attribute_value_path(:unknown)
+      return partials
+    end
+
+    def RenderHelpers.attribute_value_options(attribute_value, options = {})
+      attribute = attribute_value.attribute
+      options[:locals] ||= {}
+      options[:locals][:model] ||= attribute.model
+      options[:locals][:attribute] = attribute
+      return options
+    end
+
+    def RenderHelpers.build_attribute_value_path(partial)
+      return build_path("attribute_values", partial)
+    end
+
+
+
     # NOTE: assoc_type is sketchy at best. It tries to determine it, but in some cases it has to be guessed at, so if you have polymorphic associations it will choose the data type of the first association it finds - eg if user.things returns [Order, Product, Review] it will use the type of "order"
     def RenderHelpers.association_partials(association, options = {})
       partials = []


### PR DESCRIPTION
I wanted a clean way to customize the display of attribute values for (primarily) the index/search results view and for un-editable fields on the show page.

What I've ended up creating seems pretty close to acting like a decorator/presenter, but it does fit in nicely with the established models in Upmin. It uses the same rendering pipeline and partial naming scheme. Partials should be created under `app/views/upmin/partials/attribute_values`.

Perhaps someone has a better idea of how to implement this, perhaps leveraging Draper or one of the existing decorator gems? One thing that would be nice is an ability to customize the attribute label along with the value, but under this model it would require yet another folder full of (usually) one-line partials.