### PR TITLE
Protect upmin controllers from CSRF attacks

### DIFF
--- a/app/controllers/upmin/application_controller.rb
+++ b/app/controllers/upmin/application_controller.rb
@@ -1,4 +1,9 @@
 module Upmin
   class ApplicationController < ActionController::Base
+    if ::Rails.version.to_i < 4
+      protect_from_forgery
+    else
+      protect_from_forgery with: :exception
+    end
   end
 end


### PR DESCRIPTION
Both `DashboardController` and `ModelsController` inherit from `ApplicationController` and it is a direct subclass of `ActionController::Base`, but it doesn't call `protect_from_forgery` to turn on CSRF protection. Thus all the controllers in upmin are potentially vulnerable to CSRF attacks. This PR inserts a call in upmin's `ApplicationController` to turn on CSRF verification in the application.